### PR TITLE
Fix max markets limit

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,5 +1,5 @@
 {
   "timeout": 500000,
   "extension": ["js"],
-  "spec": "test/**/*.test.js"
+  "spec": "test/*.test.js"
 }

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,5 +1,5 @@
 {
   "timeout": 500000,
   "extension": ["js"],
-  "spec": "test/*.js"
+  "spec": "test/**/*.test.js"
 }

--- a/contracts/partial/yToken/lendingMethods.ligo
+++ b/contracts/partial/yToken/lendingMethods.ligo
@@ -296,6 +296,9 @@ function borrow(
           var token : tokenType := getToken(yAssetParams.tokenId, s.tokens);
           var borrowTokens : set(tokenId) := getTokenIds(Tezos.sender, s.borrows);
           (* should add a new token to the set to update the lastBorrowIndex *)
+          if Set.size(borrowTokens) >= s.maxMarkets
+          then failwith("yToken/max-market-limit");
+          else skip;
           borrowTokens := Set.add(yAssetParams.tokenId, borrowTokens);
           s.accounts := applyInterestToBorrows(borrowTokens, Tezos.sender, s.accounts, s.tokens);
           var userAccount : account := getAccount(Tezos.sender, yAssetParams.tokenId, s.accounts);

--- a/integration_tests/test_quick.py
+++ b/integration_tests/test_quick.py
@@ -321,15 +321,15 @@ class DexTest(TestCase):
         chain = self.create_chain_with_all_markets_and_limit(limit)
         chain.execute(self.ct.mint(0, 10000))
         chain.execute(self.ct.enterMarket(0))
-        for i in range(1, limit + 1):
+        for i in range(limit):
             chain.execute(self.ct.borrow(i, 100))
-        overflowed_market_id = limit + 1
+        overflowed_market_id = limit
         # could mint but not borrow
         res = chain.execute(self.ct.mint(overflowed_market_id, 100))
         with self.assertRaises(MichelsonRuntimeError):
             chain.execute(self.ct.borrow(overflowed_market_id, 100))
 
-        for i in range(1, limit + 1):
+        for i in range(limit):
             res = chain.execute(self.ct.repay(i, 0))
             transfers = parse_transfers(res)
             self.assertEqual(transfers[0]["destination"], contract_self_address)

--- a/test/utils/addMarkets.test.js
+++ b/test/utils/addMarkets.test.js
@@ -7,17 +7,17 @@ const {
   peter,
   dev,
   dev2,
-} = require("../scripts/sandbox/accounts");
+} = require("../../scripts/sandbox/accounts");
 
 const { strictEqual, rejects, ok } = require("assert");
 
-const { Proxy } = require("../test/utils/proxy");
-const { InterestRate } = require("../test/utils/interestRate");
-const { GetOracle } = require("../test/utils/getOracle");
-const { YToken } = require("../test/utils/yToken");
-const { FA12 } = require("../test/utils/fa12");
-const { FA2 } = require("../test/utils/fa2");
-const { Utils } = require("../test/utils/utils");
+const { Proxy } = require("./proxy");
+const { InterestRate } = require("./interestRate");
+const { GetOracle } = require("./getOracle");
+const { YToken } = require("./yToken");
+const { FA12 } = require("./fa12");
+const { FA2 } = require("./fa2");
+const { Utils } = require("./utils");
 
 const tokenMetadata0 = MichelsonMap.fromLiteral({
   symbol: Buffer.from("TST0").toString("hex"),

--- a/test/utils/interestRate.test.js
+++ b/test/utils/interestRate.test.js
@@ -1,12 +1,12 @@
-const { alice, bob, carol } = require("../scripts/sandbox/accounts");
+const { alice, bob, carol } = require("../../scripts/sandbox/accounts");
 
 const { strictEqual } = require("assert");
 
-const { InterestRate } = require("../test/utils/interestRate");
-const { SendRate } = require("../test/utils/sendRate");
-const { Utils } = require("../test/utils/utils");
+const { InterestRate } = require("./interestRate");
+const { SendRate } = require("./sendRate");
+const { Utils } = require("./utils");
 
-const { confirmOperation } = require("../scripts/confirmation");
+const { confirmOperation } = require("../../scripts/confirmation");
 
 describe("Interest tests", async () => {
   let tezos;

--- a/test/utils/proxy.test.js
+++ b/test/utils/proxy.test.js
@@ -1,15 +1,15 @@
 const { MichelsonMap } = require("@taquito/michelson-encoder");
 
-const { alice, bob, carol } = require("../scripts/sandbox/accounts");
+const { alice, bob, carol } = require("../../scripts/sandbox/accounts");
 
 const { strictEqual } = require("assert");
 
-const { Proxy } = require("../test/utils/proxy");
-const { GetOracle } = require("../test/utils/getOracle");
-const { YToken } = require("../test/utils/yToken");
-const { Utils } = require("../test/utils/utils");
+const { Proxy } = require("./proxy");
+const { GetOracle } = require("./getOracle");
+const { YToken } = require("./yToken");
+const { Utils } = require("./utils");
 
-const { confirmOperation } = require("../scripts/confirmation");
+const { confirmOperation } = require("../../scripts/confirmation");
 
 const tokenMetadata = MichelsonMap.fromLiteral({
   symbol: Buffer.from("TST").toString("hex"),


### PR DESCRIPTION
Add limit markets for borrow to avoid high fees.
Tests for maxMarkets limit for enterMarket ([test_enter_max_markets](https://github.com/LikoIlya/yupana-protocol-core/blob/a54ed7e9f8703b7c6183908e96133c72835e670c/integration_tests/test_quick.py#L157)) and borrow ([test_borrow_max_markets](https://github.com/madfish-solutions/yupana-protocol-core/blob/6e067968fb4842e950d9bba37886afd0ec95ebe0/integration_tests/test_quick.py#L319)) entrypoints.