### PR TITLE
Deadline checks and min amount params

### DIFF
--- a/contracts/partial/commonHelpers.ligo
+++ b/contracts/partial/commonHelpers.ligo
@@ -45,3 +45,8 @@ function get_nat_or_fail(
   | Some(natural) -> natural
   | None -> (failwith(error): nat)
   end;
+
+[@inline] function check_deadline(
+  const exp             : timestamp)
+                        : unit is
+  require(exp >= Tezos.now, "deadline-expired");

--- a/contracts/partial/mainTypes.ligo
+++ b/contracts/partial/mainTypes.ligo
@@ -6,8 +6,8 @@
 type useAction          is
   | Mint of yAssetParams
   | Redeem of yAssetParams
-  | Borrow of yAssetParams
-  | Repay of yAssetParams
+  | Borrow of yAssetParamsWithDL
+  | Repay of yAssetParamsWithDL
   | Liquidate of liquidateParams
   | EnterMarket of tokenId
   | ExitMarket of tokenId

--- a/contracts/partial/mainTypes.ligo
+++ b/contracts/partial/mainTypes.ligo
@@ -4,8 +4,8 @@
 #include "/proxy/priceFeedTypes.ligo"
 
 type useAction          is
-  | Mint of yAssetParams
-  | Redeem of yAssetParams
+  | Mint of yAssetParamsWithMR
+  | Redeem of yAssetParamsWithMR
   | Borrow of yAssetParamsWithDL
   | Repay of yAssetParamsWithDL
   | Liquidate of liquidateParams

--- a/contracts/partial/yToken/lendingMethods.ligo
+++ b/contracts/partial/yToken/lendingMethods.ligo
@@ -284,6 +284,8 @@ function borrow(
     var operations : list(operation) := list[];
       case p of
         Borrow(params) -> {
+          check_deadline(params.deadline);
+          
           ensureNotZero(params.amount);
 
           require(params.tokenId < s.lastTokenId, "yToken/yToken-undefined");
@@ -339,6 +341,8 @@ function repay(
     var operations : list(operation) := list[];
       case p of
         Repay(params) -> {
+          check_deadline(params.deadline);
+
           require(params.tokenId < s.lastTokenId, "yToken/yToken-undefined");
 
           var token : tokenType := getToken(params.tokenId, s.tokens);
@@ -377,6 +381,7 @@ function liquidate(
     var operations : list(operation) := list[];
       case p of
         Liquidate(params) -> {
+          check_deadline(params.deadline);
           ensureNotZero(params.amount);
           require(params.collateralToken < s.lastTokenId, "yToken/collateral-id-undefined");
           require(params.borrowToken < s.lastTokenId, "yToken/borrow-id-undefined");

--- a/contracts/partial/yToken/lendingMethods.ligo
+++ b/contracts/partial/yToken/lendingMethods.ligo
@@ -199,6 +199,7 @@ function mint(
           require(params.tokenId < s.lastTokenId, "yToken/yToken-undefined");
 
           var mintTokensF : nat := params.amount * precision;
+          require(mintTokensF >= params.minReceived, "yToken/mint/low-mint");
           var token : tokenType := getToken(params.tokenId, s.tokens);
 
           if token.totalSupplyF =/= 0n
@@ -236,6 +237,7 @@ function redeem(
           const redeemAmount : nat = if params.amount = 0n
           then userBalance * liquidityF / token.totalSupplyF / precision
           else params.amount;
+          require(redeemAmount >= params.minReceived, "yToken/redeem/low-received");
           var burnTokensF : nat := redeemAmount * precision * token.totalSupplyF / liquidityF;
 
           userBalance := get_nat_or_fail(userBalance - burnTokensF, "yToken/not-enough-tokens-to-burn");
@@ -441,6 +443,7 @@ function liquidate(
           const liquidityF : nat = getLiquidity(collateralToken);
           const exchangeRateF : nat = liquidityF * precision * collateralToken.lastPrice;
           const seizeTokensF : nat = seizeAmount / exchangeRateF;
+          require(seizeTokensF >= params.minSeized, "yToken/seize/low-seize-tokens");
           var liquidatorAccount : account := getAccount(
             Tezos.sender,
             params.collateralToken,

--- a/contracts/partial/yToken/lendingMethods.ligo
+++ b/contracts/partial/yToken/lendingMethods.ligo
@@ -199,7 +199,6 @@ function mint(
           require(params.tokenId < s.lastTokenId, "yToken/yToken-undefined");
 
           var mintTokensF : nat := params.amount * precision;
-          require(mintTokensF >= params.minReceived, "yToken/mint/low-mint");
           var token : tokenType := getToken(params.tokenId, s.tokens);
 
           if token.totalSupplyF =/= 0n
@@ -208,6 +207,8 @@ function mint(
             const liquidityF : nat = getLiquidity(token);
             mintTokensF := mintTokensF * token.totalSupplyF / liquidityF;
           } else skip;
+
+          require(mintTokensF / precision >= params.minReceived, "yToken/mint/low-mint");
 
           var userBalance : nat := getBalanceByToken(Tezos.sender, params.tokenId, s.ledger);
           userBalance := userBalance + mintTokensF;
@@ -443,7 +444,7 @@ function liquidate(
           const liquidityF : nat = getLiquidity(collateralToken);
           const exchangeRateF : nat = liquidityF * precision * collateralToken.lastPrice;
           const seizeTokensF : nat = seizeAmount / exchangeRateF;
-          require(seizeTokensF >= params.minSeized, "yToken/seize/low-seize-tokens");
+          require(seizeTokensF / precision >= params.minSeized, "yToken/seize/low-seize-tokens");
           var liquidatorAccount : account := getAccount(
             Tezos.sender,
             params.collateralToken,

--- a/contracts/partial/yToken/lendingTypes.ligo
+++ b/contracts/partial/yToken/lendingTypes.ligo
@@ -62,11 +62,18 @@ type liquidateParams    is [@layout:comb] record [
   collateralToken       : nat;
   borrower              : address;
   amount                : nat;
+  deadline              : timestamp;
 ]
 
 type yAssetParams       is [@layout:comb] record [
   tokenId               : nat;
   amount                : nat;
+]
+
+type yAssetParamsWithDL is [@layout:comb] record [
+  tokenId               : nat;
+  amount                : nat;
+  deadline              : timestamp;
 ]
 
 type fa12TransferParams   is michelson_pair(

--- a/contracts/partial/yToken/lendingTypes.ligo
+++ b/contracts/partial/yToken/lendingTypes.ligo
@@ -62,12 +62,19 @@ type liquidateParams    is [@layout:comb] record [
   collateralToken       : nat;
   borrower              : address;
   amount                : nat;
+  minSeized             : nat;
   deadline              : timestamp;
 ]
 
 type yAssetParams       is [@layout:comb] record [
   tokenId               : nat;
   amount                : nat;
+]
+
+type yAssetParamsWithMR is [@layout:comb] record [
+  tokenId               : nat;
+  amount                : nat;
+  minReceived           : nat;
 ]
 
 type yAssetParamsWithDL is [@layout:comb] record [

--- a/integration_tests/helpers.py
+++ b/integration_tests/helpers.py
@@ -33,6 +33,9 @@ burn_address = "tz1ZZZZZZZZZZZZZZZZZZZZZZZZZZZZNkiRg"
 def get_balance(res, address):
     return res.storage["ledger"][address]["balance"] 
 
+def get_balance_by_token_id(res, address, token_id): # yToken storage variant
+    return res.storage["storage"]["ledger"][(address, token_id)]
+
 def get_frozen_balance(res, address):
     return res.storage["ledger"][address]["frozenBalance"] 
 

--- a/integration_tests/test_quick.py
+++ b/integration_tests/test_quick.py
@@ -677,6 +677,48 @@ class DexTest(TestCase):
 
         with self.assertRaises(MichelsonRuntimeError):
             res = chain.execute(self.ct.borrow(0, 1, chain.now + 2))
+            
+    def test_deadline(self):
+        chain = self.create_chain_with_ab_markets()
+        
+        chain.execute(self.ct.mint(0, 100, 1))
+        chain.execute(self.ct.enterMarket(0))
+        with self.assertRaises(MichelsonRuntimeError):
+            chain.execute(self.ct.borrow(0, 50, chain.now - 1))
+        chain.execute(self.ct.borrow(0, 50, chain.now + 2))
+        with self.assertRaises(MichelsonRuntimeError):
+            chain.execute(self.ct.repay(0, 50, chain.now - 1))
+        chain.execute(self.ct.repay(0, 50, chain.now + 2))
+    
+    def test_min_received(self):
+        chain = self.create_chain_with_ab_markets()
+        with self.assertRaises(MichelsonRuntimeError):
+            chain.execute(self.ct.mint(0, 100, 101))
+        chain.execute(self.ct.mint(0, 100, 99))
+        with self.assertRaises(MichelsonRuntimeError):
+            chain.execute(self.ct.redeem(0, 50, 51))
+        chain.execute(self.ct.redeem(0, 50, 49))
+    
+    def test_liquidate_min_seized_and_deadline(self):
+        chain = LocalChain(storage=self.storage)
+        self.add_token(chain, token_a)
+        self.add_token(chain, token_b)
+
+        chain.execute(self.ct.mint(0, 100_000, 1), sender=alice)
+        chain.execute(self.ct.enterMarket(0), sender=alice)
+        chain.execute(self.ct.borrow(1, 50_000, chain.now + 2), sender=alice)
+
+        # collateral price goes down
+        res = chain.execute(self.ct.priceCallback(1, 300), sender=price_feed)
+
+        with self.assertRaises(MichelsonRuntimeError):
+            chain.execute(self.ct.liquidate(1, 0, alice, 50_001, 1, chain.now + 2), sender=bob)
+        with self.assertRaises(MichelsonRuntimeError): # minSeized check (should seize 78750)
+            res = chain.execute(self.ct.liquidate(1, 0, alice, 25_000, 80_000, chain.now + 2), sender=bob)
+        with self.assertRaises(MichelsonRuntimeError): # deadline check
+            chain.execute(self.ct.liquidate(1, 0, alice, 25_000, 1, chain.now - 1), sender=bob)
+        res = chain.execute(self.ct.liquidate(1, 0, alice, 25_000, 1, chain.now + 2), sender=bob)
+
 
     def test_should_verify_token_updates(self):
         chain = self.create_chain_with_ab_markets()

--- a/integration_tests/test_quick.py
+++ b/integration_tests/test_quick.py
@@ -69,7 +69,7 @@ class DexTest(TestCase):
         liquidity = config["liquidity"]
         if liquidity == 0: return
 
-        chain.execute(self.ct.mint(token_num, liquidity), sender=admin)
+        chain.execute(self.ct.mint(token_num, liquidity, 1), sender=admin)
 
     def create_chain_with_ab_markets(self, config_a = None, config_b = None):
         chain = LocalChain(storage=self.storage)
@@ -97,7 +97,7 @@ class DexTest(TestCase):
     def test_simple_borrow_repay(self):
         chain = self.create_chain_with_ab_markets()
 
-        res = chain.execute(self.ct.mint(0, 128))
+        res = chain.execute(self.ct.mint(0, 128, 1))
         transfers = parse_transfers(res)
         self.assertEqual(transfers[0]["destination"], contract_self_address)
         self.assertEqual(transfers[0]["source"], me)
@@ -107,9 +107,9 @@ class DexTest(TestCase):
         res = chain.execute(self.ct.enterMarket(0))
 
         with self.assertRaises(MichelsonRuntimeError):
-            res = chain.execute(self.ct.borrow(0, 65))
+            res = chain.execute(self.ct.borrow(0, 65, chain.now + 2))
         
-        res = chain.execute(self.ct.borrow(0, 10))
+        res = chain.execute(self.ct.borrow(0, 10, chain.now + 2))
         transfers = parse_transfers(res)
         self.assertEqual(transfers[0]["destination"], me)
         self.assertEqual(transfers[0]["source"], contract_self_address)
@@ -117,9 +117,9 @@ class DexTest(TestCase):
         self.assertEqual(transfers[0]["token_address"], token_a_address)
         
         with self.assertRaises(MichelsonRuntimeError):
-            res = chain.execute(self.ct.repay(0, 11))
+            res = chain.execute(self.ct.repay(0, 11, chain.now + 2))
 
-        res = chain.execute(self.ct.repay(0, 10))
+        res = chain.execute(self.ct.repay(0, 10, chain.now + 2))
         transfers = parse_transfers(res)
         self.assertEqual(transfers[0]["destination"], contract_self_address)
         self.assertEqual(transfers[0]["source"], me)
@@ -127,14 +127,14 @@ class DexTest(TestCase):
         self.assertEqual(transfers[0]["token_address"], token_a_address)
 
         with self.assertRaises(MichelsonRuntimeError):
-            res = chain.execute(self.ct.repay(0, 1))
+            res = chain.execute(self.ct.repay(0, 1, chain.now + 2))
 
         with self.assertRaises(MichelsonRuntimeError):
-            res = chain.execute(self.ct.redeem(0, 129))
+            res = chain.execute(self.ct.redeem(0, 129, 1))
 
         res = chain.execute(self.ct.exitMarket(0))
 
-        res = chain.execute(self.ct.redeem(0, 128))
+        res = chain.execute(self.ct.redeem(0, 128, 1))
         transfers = parse_transfers(res)
         self.assertEqual(transfers[0]["destination"], me)
         self.assertEqual(transfers[0]["source"], contract_self_address)
@@ -144,11 +144,11 @@ class DexTest(TestCase):
     def test_can_simply_redeem(self):
         chain = self.create_chain_with_ab_markets()
 
-        chain.execute(self.ct.mint(0, 100))
+        chain.execute(self.ct.mint(0, 100, 1))
         chain.execute(self.ct.enterMarket(0))
         chain.execute(self.ct.exitMarket(0))
         
-        res = chain.execute(self.ct.redeem(0, 100))
+        res = chain.execute(self.ct.redeem(0, 100, 1))
 
         transfers = parse_transfers(res)
         self.assertEqual(transfers[0]["destination"], me)
@@ -160,18 +160,18 @@ class DexTest(TestCase):
         limit = 3
         chain = self.create_chain_with_all_markets_and_limit(limit)
         for i in range(limit):
-            chain.execute(self.ct.mint(i, 100))
+            chain.execute(self.ct.mint(i, 100, 1))
             chain.execute(self.ct.enterMarket(i))
         overflowed_market_id = limit
 
         # could mint but not enter
-        chain.execute(self.ct.mint(overflowed_market_id, 100))
+        chain.execute(self.ct.mint(overflowed_market_id, 100, 1))
         with self.assertRaises(MichelsonRuntimeError):
             chain.execute(self.ct.enterMarket(overflowed_market_id))
 
         for i in range(limit):
             chain.execute(self.ct.exitMarket(i))
-            res = chain.execute(self.ct.redeem(i, 100))
+            res = chain.execute(self.ct.redeem(i, 100, 1))
             transfers = parse_transfers(res)
             self.assertEqual(transfers[0]["destination"], me)
             self.assertEqual(transfers[0]["source"], contract_self_address)
@@ -180,36 +180,36 @@ class DexTest(TestCase):
     def test_cant_redeem_too_much_when_on_market(self):
         chain = self.create_chain_with_ab_markets()
 
-        chain.execute(self.ct.mint(0, 100), sender=alice)
+        chain.execute(self.ct.mint(0, 100, 1), sender=alice)
         chain.execute(self.ct.enterMarket(0), sender=alice)
         
-        chain.execute(self.ct.borrow(1, 25), sender=alice)
+        chain.execute(self.ct.borrow(1, 25, chain.now +2), sender=alice)
         
         with self.assertRaises(MichelsonRuntimeError):
-            chain.execute(self.ct.redeem(0, 51), sender=alice)
+            chain.execute(self.ct.redeem(0, 51, 1), sender=alice)
 
         with self.assertRaises(MichelsonRuntimeError):
-            chain.execute(self.ct.liquidate(1, 0, me, 1), sender=bob)
+            chain.execute(self.ct.liquidate(1, 0, me, 1, 1, chain.now + 2), sender=bob)
 
-        chain.execute(self.ct.redeem(0, 50), sender=alice)
+        chain.execute(self.ct.redeem(0, 50, 1), sender=alice)
 
         with self.assertRaises(MichelsonRuntimeError):
-            chain.execute(self.ct.redeem(0, 1), sender=alice)
+            chain.execute(self.ct.redeem(0, 1, 1), sender=alice)
         
 
     def test_cant_redeem_when_borrowed(self):
         chain = self.create_chain_with_ab_markets()
 
-        chain.execute(self.ct.mint(0, 100))
+        chain.execute(self.ct.mint(0, 100, 1))
         chain.execute(self.ct.enterMarket(0))
         
-        res = chain.execute(self.ct.borrow(1, 50))
+        res = chain.execute(self.ct.borrow(1, 50, chain.now + 2))
         
         with self.assertRaises(MichelsonRuntimeError):
             chain.execute(self.ct.exitMarket(0))
 
         with self.assertRaises(MichelsonRuntimeError):
-            chain.execute(self.ct.redeem(0, 10))
+            chain.execute(self.ct.redeem(0, 10, 1))
 
         print(calc_utilization_rate(res.storage["storage"], 0))
         print(calc_utilization_rate(res.storage["storage"], 1))
@@ -217,9 +217,9 @@ class DexTest(TestCase):
     def test_can_redeem_when_liquidated(self):
         chain = self.create_chain_with_ab_markets()
 
-        chain.execute(self.ct.mint(0, 100))
+        chain.execute(self.ct.mint(0, 100, 1))
         chain.execute(self.ct.enterMarket(0))
-        chain.execute(self.ct.borrow(1, 50))
+        chain.execute(self.ct.borrow(1, 50, 1))
 
         self.update_price_and_interest(chain, 0, 50, 0)
         self.update_price_and_interest(chain, 1, 100, 0)
@@ -227,7 +227,7 @@ class DexTest(TestCase):
         # check that can't liquidate without price udpdate even tho liquidation is achieved
         chain.advance_blocks(1)
         with self.assertRaises(MichelsonRuntimeError) as error:
-            chain.execute(self.ct.liquidate(1, 0, me, 25), sender=bob)
+            chain.execute(self.ct.liquidate(1, 0, me, 25, 1, chain.now + 2), sender=bob)
         self.assertIn("update", error.exception.args[-1])
 
         self.update_price_and_interest(chain, 0, 50, 0)
@@ -237,7 +237,7 @@ class DexTest(TestCase):
 
         expected_reserves_bonus = calculate_reserves_bonus_by_liqidation(chain.storage['storage']['tokens'], 1, 0, 25)
 
-        res = chain.execute(self.ct.liquidate(1, 0, me, 25), sender=bob)
+        res = chain.execute(self.ct.liquidate(1, 0, me, 25, 1, chain.now + 2), sender=bob)
 
         actual_reserves = get_reserves(res, 0)
         actual_reserves_bonus = (actual_reserves - initial_reserves)
@@ -250,10 +250,10 @@ class DexTest(TestCase):
         self.assertEqual(transfers[0]["amount"], 25)
         self.assertEqual(transfers[0]["token_address"], token_b_address)
 
-        chain.execute(self.ct.repay(1, 25))
+        chain.execute(self.ct.repay(1, 25, chain.now + 2))
         chain.execute(self.ct.exitMarket(0))
 
-        res = chain.execute(self.ct.redeem(0, 1))
+        res = chain.execute(self.ct.redeem(0, 1, 1))
         transfers = parse_transfers(res)
         self.assertEqual(transfers[0]["destination"], me)
         self.assertEqual(transfers[0]["source"], contract_self_address)
@@ -263,17 +263,17 @@ class DexTest(TestCase):
     def test_mint_redeem(self):
         chain = self.create_chain_with_ab_markets()
 
-        res = chain.execute(self.ct.mint(0, 1))
-        res = chain.execute(self.ct.mint(1, 100_000))
+        res = chain.execute(self.ct.mint(0, 1, 1))
+        res = chain.execute(self.ct.mint(1, 100_000, 1))
 
         # can't redeem more
         with self.assertRaises(MichelsonRuntimeError):
-            res = chain.execute(self.ct.redeem(0, 2))
+            res = chain.execute(self.ct.redeem(0, 2, 1))
         with self.assertRaises(MichelsonRuntimeError):
-            res = chain.execute(self.ct.redeem(1, 100_001))
+            res = chain.execute(self.ct.redeem(1, 100_001, 1))
 
         # fully redeem token a
-        res = chain.execute(self.ct.redeem(0, 1))
+        res = chain.execute(self.ct.redeem(0, 1, 1))
         transfers = parse_transfers(res)
         self.assertEqual(transfers[0]["destination"], me)
         self.assertEqual(transfers[0]["source"], contract_self_address)
@@ -281,7 +281,7 @@ class DexTest(TestCase):
         self.assertEqual(transfers[0]["token_address"], token_a_address)
         
         # partially redeem token_b
-        res = chain.execute(self.ct.redeem(1, 50_000))
+        res = chain.execute(self.ct.redeem(1, 50_000, 1))
         transfers = parse_transfers(res)
         self.assertEqual(transfers[0]["destination"], me)
         self.assertEqual(transfers[0]["source"], contract_self_address)
@@ -290,10 +290,10 @@ class DexTest(TestCase):
         
         # cant redeem more than left
         with self.assertRaises(MichelsonRuntimeError):
-            res = chain.execute(self.ct.redeem(1, 50_001))
+            res = chain.execute(self.ct.redeem(1, 50_001, 1))
 
         # redeem the rest
-        res = chain.execute(self.ct.redeem(1, 50_000))
+        res = chain.execute(self.ct.redeem(1, 50_000, 1))
         transfers = parse_transfers(res)
         self.assertEqual(transfers[0]["destination"], me)
         self.assertEqual(transfers[0]["source"], contract_self_address)
@@ -302,7 +302,7 @@ class DexTest(TestCase):
         
         # cant redeem anymore
         with self.assertRaises(MichelsonRuntimeError):
-            res = chain.execute(self.ct.redeem(1, 1))
+            res = chain.execute(self.ct.redeem(1, 1, 1))
 
 
     def test_borrow_too_much(self):
@@ -310,13 +310,13 @@ class DexTest(TestCase):
         self.add_token(chain, token_a)
         self.add_token(chain, token_b)
 
-        res = chain.execute(self.ct.mint(0, 100), sender=alice)
+        res = chain.execute(self.ct.mint(0, 100, 1), sender=alice)
         res = chain.execute(self.ct.enterMarket(0), sender=alice)
 
         with self.assertRaises(MichelsonRuntimeError):
-            res = chain.execute(self.ct.borrow(1, 51), sender=alice)
+            res = chain.execute(self.ct.borrow(1, 51, chain.now + 2), sender=alice)
 
-        res = chain.execute(self.ct.borrow(1, 50), sender=alice)
+        res = chain.execute(self.ct.borrow(1, 50, chain.now + 2), sender=alice)
         transfers = parse_transfers(res)
         self.assertEqual(transfers[0]["source"], contract_self_address)
         self.assertEqual(transfers[0]["destination"], alice)
@@ -325,23 +325,23 @@ class DexTest(TestCase):
 
         # can't borrow anymore due to collateral factor
         with self.assertRaises(MichelsonRuntimeError):
-            res = chain.execute(self.ct.borrow(1, 1), sender=alice)
+            res = chain.execute(self.ct.borrow(1, 1, 1), sender=alice)
             
     def test_borrow_max_markets(self):
         limit = 2
         chain = self.create_chain_with_all_markets_and_limit(limit)
-        chain.execute(self.ct.mint(0, 10000))
+        chain.execute(self.ct.mint(0, 10000, 1))
         chain.execute(self.ct.enterMarket(0))
         for i in range(limit):
-            chain.execute(self.ct.borrow(i, 100))
+            chain.execute(self.ct.borrow(i, 100, chain.now + 2))
         overflowed_market_id = limit
         # could mint but not borrow
-        res = chain.execute(self.ct.mint(overflowed_market_id, 100))
+        res = chain.execute(self.ct.mint(overflowed_market_id, 100, 1))
         with self.assertRaises(MichelsonRuntimeError):
-            chain.execute(self.ct.borrow(overflowed_market_id, 100))
+            chain.execute(self.ct.borrow(overflowed_market_id, 100, chain.now + 2))
 
         for i in range(limit):
-            res = chain.execute(self.ct.repay(i, 0))
+            res = chain.execute(self.ct.repay(i, 0, chain.now + 2))
             transfers = parse_transfers(res)
             self.assertEqual(transfers[0]["destination"], contract_self_address)
             self.assertEqual(transfers[0]["source"], me)
@@ -352,9 +352,9 @@ class DexTest(TestCase):
         self.add_token(chain, token_a)
         self.add_token(chain, token_b)
 
-        res = chain.execute(self.ct.mint(0, 100_000), sender=alice)
+        res = chain.execute(self.ct.mint(0, 100_000, 1), sender=alice)
         res = chain.execute(self.ct.enterMarket(0), sender=alice)
-        res = chain.execute(self.ct.borrow(1, 50_000), sender=alice)
+        res = chain.execute(self.ct.borrow(1, 50_000, chain.now + 2), sender=alice)
 
         # collateral price goes down
         res = chain.execute(self.ct.priceCallback(0, 30), sender=price_feed)
@@ -363,14 +363,14 @@ class DexTest(TestCase):
         # return
 
         with self.assertRaises(MichelsonRuntimeError):
-            chain.execute(self.ct.liquidate(1, 0, alice, 25_001), sender=bob)
+            chain.execute(self.ct.liquidate(1, 0, alice, 25_001, 1, chain.now + 2), sender=bob)
             
             
         initial_reserves = get_reserves(res, 0)
 
         expected_reserves_bonus = calculate_reserves_bonus_by_liqidation(res.storage['storage']['tokens'], 1, 0, 10_000)
 
-        res = chain.execute(self.ct.liquidate(1, 0, alice, 10_000), sender=bob)
+        res = chain.execute(self.ct.liquidate(1, 0, alice, 10_000, 1, chain.now + 2), sender=bob)
 
         actual_reserves = get_reserves(res, 0)
         actual_reserves_bonus = (actual_reserves - initial_reserves)
@@ -389,7 +389,7 @@ class DexTest(TestCase):
 
         expected_reserves_bonus = calculate_reserves_bonus_by_liqidation(res.storage['storage']['tokens'], 1, 0, 15_000)
 
-        res = chain.execute(self.ct.liquidate(1, 0, alice, 15_000), sender=bob)
+        res = chain.execute(self.ct.liquidate(1, 0, alice, 15_000, 1, chain.now + 2), sender=bob)
 
         actual_reserves = get_reserves(res, 0)
         actual_reserves_bonus = (actual_reserves - initial_reserves)
@@ -407,22 +407,22 @@ class DexTest(TestCase):
         self.add_token(chain, token_a)
         self.add_token(chain, token_b)
 
-        chain.execute(self.ct.mint(0, 100_000), sender=alice)
+        chain.execute(self.ct.mint(0, 100_000, 1), sender=alice)
         chain.execute(self.ct.enterMarket(0), sender=alice)
-        chain.execute(self.ct.borrow(1, 50_000), sender=alice)
+        chain.execute(self.ct.borrow(1, 50_000, chain.now + 2), sender=alice)
 
         # collateral price goes down
         res = chain.execute(self.ct.priceCallback(1, 300), sender=price_feed)
 
         with self.assertRaises(MichelsonRuntimeError):
-            chain.execute(self.ct.liquidate(1, 0, alice, 50_001), sender=bob)
+            chain.execute(self.ct.liquidate(1, 0, alice, 50_001, 1, chain.now + 2), sender=bob)
             
             
         initial_reserves = get_reserves(res, 0)
 
         expected_reserves_bonus = calculate_reserves_bonus_by_liqidation(res.storage['storage']['tokens'], 1, 0, 25_000)
 
-        res = chain.execute(self.ct.liquidate(1, 0, alice, 25_000), sender=bob)
+        res = chain.execute(self.ct.liquidate(1, 0, alice, 25_000, 1, chain.now + 2), sender=bob)
 
         actual_reserves = get_reserves(res, 0)
         actual_reserves_bonus = (actual_reserves - initial_reserves)
@@ -440,46 +440,46 @@ class DexTest(TestCase):
         self.add_token(chain, token_a)
         self.add_token(chain, token_b)
         
-        chain.execute(self.ct.mint(0, 100_000), sender=alice)
+        chain.execute(self.ct.mint(0, 100_000, 1), sender=alice)
         chain.execute(self.ct.enterMarket(0), sender=alice)
-        chain.execute(self.ct.borrow(1, 50_000), sender=alice)
+        chain.execute(self.ct.borrow(1, 50_000, chain.now + 2), sender=alice)
 
         # collateral price goes down
         res = chain.execute(self.ct.priceCallback(1, 300), sender=price_feed)
 
         with self.assertRaises(MichelsonRuntimeError):
-            chain.execute(self.ct.liquidate(1, 0, alice, 50_001), sender=bob)
+            chain.execute(self.ct.liquidate(1, 0, alice, 50_001, 1, chain.now + 2), sender=bob)
             
         
         initial_reserves = get_reserves(res, 0)
 
         expected_reserves_bonus = calculate_reserves_bonus_by_liqidation(res.storage['storage']['tokens'], 1, 0, 25_000)
 
-        res = chain.execute(self.ct.liquidate(1, 0, alice, 25_000), sender=bob)
+        res = chain.execute(self.ct.liquidate(1, 0, alice, 25_000, 1, chain.now + 2), sender=bob)
 
         actual_reserves = get_reserves(res, 0)
         actual_reserves_bonus = (actual_reserves - initial_reserves)
         self.assertAlmostEqual(actual_reserves_bonus, expected_reserves_bonus)
         
-        chain.execute(self.ct.repay(1,0), sender=alice)
+        chain.execute(self.ct.repay(1,0, chain.now + 2), sender=alice)
 
         # check that admin is able to withdraw all of his initially povided funds
         # do not perform an actual withdrawal.
-        res = chain.interpret(self.ct.redeem(1, 0), sender=admin)
+        res = chain.interpret(self.ct.redeem(1, 0, 1), sender=admin)
         txs = parse_transfers(res)
         self.assertEqual(len(txs), 1)
         self.assertEqual(txs[0]["amount"], 100_000)
 
         # another person just does usual stuff after another one is liquidated
-        chain.execute(self.ct.mint(0, 70_000), sender=carol)
+        chain.execute(self.ct.mint(0, 70_000, 1), sender=carol)
         chain.execute(self.ct.enterMarket(0), sender=carol)
-        chain.execute(self.ct.borrow(1, 10_000), sender=carol)
+        chain.execute(self.ct.borrow(1, 10_000, chain.now + 2), sender=carol)
 
         chain.advance_blocks(1)
         self.update_price_and_interest(chain, 0, 100, one_percent_per_second)
         self.update_price_and_interest(chain, 1, 100, one_percent_per_second)
 
-        res = chain.execute(self.ct.repay(1, 0), sender=carol)
+        res = chain.execute(self.ct.repay(1, 0, chain.now + 2), sender=carol)
         txs = parse_transfers(res)
         self.assertEqual(len(txs), 1)
         self.assertEqual(txs[0]["amount"], 13_000)
@@ -491,15 +491,15 @@ class DexTest(TestCase):
         self.add_token(chain, token_b)
         self.add_token(chain, token_c)
 
-        chain.execute(self.ct.mint(0, 100_000))
-        chain.execute(self.ct.mint(1, 100_000))
+        chain.execute(self.ct.mint(0, 100_000, 1))
+        chain.execute(self.ct.mint(1, 100_000, 1))
         chain.execute(self.ct.enterMarket(0))
         chain.execute(self.ct.enterMarket(1))
         
         with self.assertRaises(MichelsonRuntimeError):
-            chain.execute(self.ct.borrow(2, 100_001))
+            chain.execute(self.ct.borrow(2, 100_001, chain.now + 2))
         
-        chain.execute(self.ct.borrow(2, 100_000))
+        chain.execute(self.ct.borrow(2, 100_000, chain.now + 2))
 
         # none of collaterals can leave
         with self.assertRaises(MichelsonRuntimeError):
@@ -508,7 +508,7 @@ class DexTest(TestCase):
             chain.execute(self.ct.exitMarket(1))
 
         # after returning the half one collateral can fully leave
-        chain.execute(self.ct.repay(2, 50_000))
+        chain.execute(self.ct.repay(2, 50_000, chain.now + 2))
         chain.execute(self.ct.exitMarket(0))
 
     def test_multicollateral_can_switch_collateral(self):
@@ -517,12 +517,12 @@ class DexTest(TestCase):
         self.add_token(chain, token_b)
         self.add_token(chain, token_c)
 
-        chain.execute(self.ct.mint(0, 100_000))
-        chain.execute(self.ct.mint(1, 100_000))
+        chain.execute(self.ct.mint(0, 100_000, 1))
+        chain.execute(self.ct.mint(1, 100_000, 1))
         chain.execute(self.ct.enterMarket(0))
         chain.execute(self.ct.enterMarket(1))
             
-        chain.execute(self.ct.borrow(2, 50_000))
+        chain.execute(self.ct.borrow(2, 50_000, chain.now + 2))
 
         # second collateral is basically unused
         chain.interpret(self.ct.exitMarket(1))
@@ -532,9 +532,9 @@ class DexTest(TestCase):
         # even though the price has changed, nothing to liquidate
         # second collateral fully covers the debt
         with self.assertRaises(MichelsonRuntimeError):
-            chain.execute(self.ct.liquidate(2, 0, me, 1), sender=bob)
+            chain.execute(self.ct.liquidate(2, 0, me, 1, 1, chain.now + 2), sender=bob)
 
-        chain.execute(self.ct.repay(2, 50_000))
+        chain.execute(self.ct.repay(2, 50_000, chain.now + 2))
 
         chain.execute(self.ct.enterMarket(0))
         chain.execute(self.ct.enterMarket(1))
@@ -542,9 +542,9 @@ class DexTest(TestCase):
     def test_liquidate_due_to_interest_rate(self):
         chain = self.create_chain_with_ab_markets()
 
-        chain.execute(self.ct.mint(0, 10))
+        chain.execute(self.ct.mint(0, 10, 1))
         chain.execute(self.ct.enterMarket(0))
-        chain.execute(self.ct.borrow(1, 5))
+        chain.execute(self.ct.borrow(1, 5, chain.now + 2))
 
         chain.advance_blocks(1)
         chain.execute(self.ct.updateInterest(0))
@@ -558,20 +558,20 @@ class DexTest(TestCase):
         
         # verify only 20 tokens could be repayed
         with self.assertRaises(MichelsonRuntimeError):
-            chain.interpret(self.ct.repay(1, 21))
-        chain.interpret(self.ct.repay(1, 20))
+            chain.interpret(self.ct.repay(1, 21, chain.now + 2))
+        chain.interpret(self.ct.repay(1, 20, chain.now + 2))
 
 
 
         # can liquidate at least 9 tokens which is 0.5 * 20 - 1
         with self.assertRaises(MichelsonRuntimeError):
-            chain.execute(self.ct.liquidate(1, 0, me, 11), sender=bob)
+            chain.execute(self.ct.liquidate(1, 0, me, 11, 1, chain.now + 2), sender=bob)
             
         initial_reserves = get_reserves(chain, 0)
 
         expected_reserves_bonus = calculate_reserves_bonus_by_liqidation(chain.storage['storage']['tokens'], 1, 0, 9)
 
-        res = chain.execute(self.ct.liquidate(1, 0, me, 9), sender=bob)
+        res = chain.execute(self.ct.liquidate(1, 0, me, 9, 1, chain.now + 2), sender=bob)
 
         actual_reserves = get_reserves(res, 0)
         actual_reserves_bonus = (actual_reserves - initial_reserves)
@@ -593,12 +593,12 @@ class DexTest(TestCase):
         self.add_token(chain, token_a) # token a provided by admin
         self.add_token(chain, token_b, token_b_config) # token b will be provided by alice
 
-        chain.execute(self.ct.mint(1, 100_000), sender=alice)
+        chain.execute(self.ct.mint(1, 100_000, 1), sender=alice)
         # chain.execute(self.ct.redeem(1, 100_010), sender=alice)
 
-        chain.execute(self.ct.mint(0, 20_000))
+        chain.execute(self.ct.mint(0, 20_000, 1))
         chain.execute(self.ct.enterMarket(0))
-        chain.execute(self.ct.borrow(1, 10_000))
+        chain.execute(self.ct.borrow(1, 10_000, chain.now + 2))
         
         chain.advance_blocks(1)
 
@@ -611,16 +611,16 @@ class DexTest(TestCase):
         chain.execute(self.ct.accrueInterest(1, 100_000_000_000_000), sender=interest_model)
         chain.execute(self.ct.priceCallback(1, 100), sender=price_feed)
                   
-        chain.execute(self.ct.repay(1, 10_030))
+        chain.execute(self.ct.repay(1, 10_030, chain.now + 2))
         chain.execute(self.ct.exitMarket(0))
 
         # pprint_aux(res.storage["storage"])
         # return
 
         with self.assertRaises(MichelsonRuntimeError):
-            chain.execute(self.ct.redeem(1, 100_016), sender=alice)
+            chain.execute(self.ct.redeem(1, 100_016, 1), sender=alice)
 
-        chain.execute(self.ct.redeem(1, 100_015), sender=alice)
+        chain.execute(self.ct.redeem(1, 100_015, 1), sender=alice)
 
         with self.assertRaises(MichelsonRuntimeError):
             chain.execute(self.ct.withdrawReserve(1, 16), sender=admin)
@@ -633,27 +633,27 @@ class DexTest(TestCase):
     def test_whale_redeems_its_collateral(self):
         chain = self.create_chain_with_ab_markets()
         
-        chain.execute(self.ct.mint(0, 100_000))
+        chain.execute(self.ct.mint(0, 100_000, 1))
         chain.execute(self.ct.enterMarket(0))
-        chain.execute(self.ct.borrow(1, 50_000))
+        chain.execute(self.ct.borrow(1, 50_000, chain.now + 2))
 
         # since admin is our main whale he can take funds
-        chain.execute(self.ct.redeem(1, 50_000), sender=admin)
+        chain.execute(self.ct.redeem(1, 50_000, 1), sender=admin)
         
         with self.assertRaises(MichelsonRuntimeError):        
-            chain.execute(self.ct.redeem(1, 1), sender=admin)
+            chain.execute(self.ct.redeem(1, 1, 1), sender=admin)
 
 
     def test_collateral_interest_avoids_liquidation(self):
         chain = self.create_chain_with_ab_markets()
         
-        chain.execute(self.ct.mint(0, 10), sender=alice)
+        chain.execute(self.ct.mint(0, 10, 1), sender=alice)
         chain.execute(self.ct.enterMarket(0), sender=alice)
-        chain.execute(self.ct.borrow(1, 5), sender=alice)
+        chain.execute(self.ct.borrow(1, 5, chain.now + 2), sender=alice)
 
-        chain.execute(self.ct.mint(1, 10), sender=bob)
+        chain.execute(self.ct.mint(1, 10, 1), sender=bob)
         chain.execute(self.ct.enterMarket(1), sender=bob)
-        chain.execute(self.ct.borrow(0, 5), sender=bob)
+        chain.execute(self.ct.borrow(0, 5, chain.now + 2), sender=bob)
 
         chain.advance_blocks(1)
         
@@ -671,12 +671,12 @@ class DexTest(TestCase):
     def test_token_self_borrow(self):
         chain = self.create_chain_with_ab_markets()
         
-        chain.execute(self.ct.mint(0, 100))
+        chain.execute(self.ct.mint(0, 100, 1))
         chain.execute(self.ct.enterMarket(0))
-        chain.execute(self.ct.borrow(0, 50))
+        chain.execute(self.ct.borrow(0, 50, chain.now + 2))
 
         with self.assertRaises(MichelsonRuntimeError):
-            res = chain.execute(self.ct.borrow(0, 1))
+            res = chain.execute(self.ct.borrow(0, 1, chain.now + 2))
 
     def test_should_verify_token_updates(self):
         chain = self.create_chain_with_ab_markets()
@@ -684,11 +684,11 @@ class DexTest(TestCase):
         chain.advance_blocks(1)
 
         with self.assertRaises(MichelsonRuntimeError) as error:
-            chain.execute(self.ct.mint(0, 100))
+            chain.execute(self.ct.mint(0, 100, 1))
         self.assertIn("update", error.exception.args[-1])
 
         with self.assertRaises(MichelsonRuntimeError) as error:
-            chain.execute(self.ct.borrow(0, 100))
+            chain.execute(self.ct.borrow(0, 100, chain.now + 2))
         self.assertIn("update", error.exception.args[-1])
 
     def test_threshold(self):
@@ -696,14 +696,14 @@ class DexTest(TestCase):
         self.add_token(chain, token_a)
         self.add_token(chain, token_b)
 
-        chain.execute(self.ct.mint(0, 100))
+        chain.execute(self.ct.mint(0, 100, 1))
         chain.execute(self.ct.enterMarket(0))
-        chain.execute(self.ct.borrow(1, 50))
+        chain.execute(self.ct.borrow(1, 50, chain.now + 2))
         
         # cannot yet liquidate since 0.5 // 0.63 < 0.8
         with self.assertRaises(MichelsonRuntimeError) as error:
             chain.execute(self.ct.priceCallback(0, 63), sender=price_feed)
-            chain.execute(self.ct.liquidate(1, 0, me, 25), sender=bob)
+            chain.execute(self.ct.liquidate(1, 0, me, 25, 1, chain.now + 2), sender=bob)
             
         res = chain.execute(self.ct.priceCallback(0, 62), sender=price_feed)
         
@@ -711,7 +711,7 @@ class DexTest(TestCase):
 
         expected_reserves_bonus = calculate_reserves_bonus_by_liqidation(res.storage['storage']['tokens'], 1, 0, 25)
 
-        res = chain.execute(self.ct.liquidate(1, 0, me, 25), sender=bob)
+        res = chain.execute(self.ct.liquidate(1, 0, me, 25, 1, chain.now + 2), sender=bob)
 
         actual_reserves = get_reserves(res, 0)
         actual_reserves_bonus = (actual_reserves - initial_reserves)
@@ -724,30 +724,30 @@ class DexTest(TestCase):
         self.add_token(chain, token_b)
 
         with self.assertRaises(MichelsonRuntimeError) as error:
-            chain.execute(self.ct.mint(0, 0))
+            chain.execute(self.ct.mint(0, 0, 1))
 
-        chain.execute(self.ct.mint(0, 100))
+        chain.execute(self.ct.mint(0, 100, 1))
         chain.execute(self.ct.enterMarket(0))
         
         with self.assertRaises(MichelsonRuntimeError) as error:
-            chain.execute(self.ct.borrow(1, 0))
+            chain.execute(self.ct.borrow(1, 0, chain.now + 2))
 
-        res = chain.interpret(self.ct.repay(0, 0))
+        res = chain.interpret(self.ct.repay(0, 0, chain.now + 2))
         transfers = parse_transfers(res)
         self.assertEqual(transfers[0]["amount"], 0)
 
-        chain.execute(self.ct.borrow(1, 33))
-        res = chain.execute(self.ct.repay(1, 0))
+        chain.execute(self.ct.borrow(1, 33, chain.now + 2))
+        res = chain.execute(self.ct.repay(1, 0, chain.now + 2))
         transfers = parse_transfers(res)
         self.assertEqual(transfers[0]["amount"], 33)
 
         chain.execute(self.ct.exitMarket(0))
 
-        res = chain.execute(self.ct.redeem(0, 0))
+        res = chain.execute(self.ct.redeem(0, 0, 1))
         transfers = parse_transfers(res)
         self.assertEqual(transfers[0]["amount"], 100)
 
-        res = chain.execute(self.ct.redeem(0, 0))
+        res = chain.execute(self.ct.redeem(0, 0, 0))
         transfers = parse_transfers(res)
         self.assertEqual(transfers[0]["amount"], 0)
 
@@ -755,7 +755,7 @@ class DexTest(TestCase):
         chain.execute(self.ct.updateInterest(0))
         chain.execute(self.ct.priceCallback(0, 100), sender=price_feed)
 
-        res = chain.execute(self.ct.redeem(0, 0))
+        res = chain.execute(self.ct.redeem(0, 0, 0))
         transfers = parse_transfers(res)
         self.assertEqual(transfers[0]["amount"], 0)
         
@@ -773,16 +773,16 @@ class DexTest(TestCase):
         self.add_token(chain, token_a) # token a provided by admin
         self.add_token(chain, token_b, token_b_config) # token b will be provided by alice
 
-        res = chain.execute(self.ct.mint(1, 50), sender=bob)
+        res = chain.execute(self.ct.mint(1, 50, 1), sender=bob)
 
         old_storage = res.storage["storage"]
 
-        chain.execute(self.ct.mint(0, 100))
+        chain.execute(self.ct.mint(0, 100, 1))
         chain.execute(self.ct.enterMarket(0))
-        chain.execute(self.ct.borrow(1, 50))
-        chain.execute(self.ct.repay(1, 50))
+        chain.execute(self.ct.borrow(1, 50, chain.now + 2))
+        chain.execute(self.ct.repay(1, 50, 1))
         chain.execute(self.ct.exitMarket(0))
-        res = chain.execute(self.ct.redeem(0, 100))
+        res = chain.execute(self.ct.redeem(0, 100, 1))
 
         # do the same as above after ten blocks after supply was drained
         # check that everything stays the same
@@ -792,19 +792,19 @@ class DexTest(TestCase):
         chain.execute(self.ct.updateInterest(1))
         chain.execute(self.ct.priceCallback(1, 100), sender=price_feed)
 
-        chain.execute(self.ct.mint(0, 100))
+        chain.execute(self.ct.mint(0, 100, 1))
         chain.execute(self.ct.enterMarket(0))
         with self.assertRaises(MichelsonRuntimeError):
-            chain.execute(self.ct.borrow(1, 51))
+            chain.execute(self.ct.borrow(1, 51, chain.now + 2))
 
-        chain.execute(self.ct.borrow(1, 50))
-        chain.execute(self.ct.repay(1, 50))
+        chain.execute(self.ct.borrow(1, 50, chain.now + 2))
+        chain.execute(self.ct.repay(1, 50, chain.now + 2))
         chain.execute(self.ct.exitMarket(0))
 
         with self.assertRaises(MichelsonRuntimeError):
-            chain.execute(self.ct.borrow(1, 101))
+            chain.execute(self.ct.borrow(1, 101, chain.now + 2))
 
-        chain.execute(self.ct.redeem(0, 100))
+        chain.execute(self.ct.redeem(0, 100, 1))
 
     def test_two_borrows_interest_rate(self):
         chain = LocalChain(storage=self.storage)
@@ -812,10 +812,10 @@ class DexTest(TestCase):
         self.add_token(chain, token_b)
         self.add_token(chain, token_c)
 
-        chain.execute(self.ct.mint(0, 40_000))
+        chain.execute(self.ct.mint(0, 40_000, 1))
         chain.execute(self.ct.enterMarket(0))
-        chain.execute(self.ct.borrow(1, 10_000))
-        chain.execute(self.ct.borrow(2, 10_000))
+        chain.execute(self.ct.borrow(1, 10_000, chain.now + 2))
+        chain.execute(self.ct.borrow(2, 10_000, chain.now + 2))
         
         chain.advance_blocks(1)
 
@@ -833,13 +833,13 @@ class DexTest(TestCase):
         chain.execute(self.ct.accrueInterest(2, 100_000_000_000_000), sender=interest_model)
         chain.execute(self.ct.priceCallback(2, 100), sender=price_feed)
                   
-        chain.execute(self.ct.repay(1, 10_030))
+        chain.execute(self.ct.repay(1, 10_030, chain.now + 2))
 
         # borrow and immediately repay to invoke applyInterestToBorrows
-        res = chain.execute(self.ct.borrow(1, 1))
-        chain.execute(self.ct.repay(1, 1))
+        res = chain.execute(self.ct.borrow(1, 1, chain.now + 2))
+        chain.execute(self.ct.repay(1, 1, chain.now + 2))
 
-        res = chain.execute(self.ct.repay(2, 10_030))
+        res = chain.execute(self.ct.repay(2, 10_030, chain.now + 2))
         chain.execute(self.ct.exitMarket(0))
 
 
@@ -848,33 +848,33 @@ class DexTest(TestCase):
         self.add_token(chain, token_a)
         self.add_token(chain, token_b)
 
-        chain.execute(self.ct.mint(0, 40_000))
+        chain.execute(self.ct.mint(0, 40_000, 1))
         chain.execute(self.ct.enterMarket(0))
-        chain.execute(self.ct.borrow(1, 10_000))
+        chain.execute(self.ct.borrow(1, 10_000, chain.now + 2))
         
         chain.advance_blocks(1)
         self.update_price_and_interest(chain, 0, 100, one_percent_per_second)
         self.update_price_and_interest(chain, 1, 100, one_percent_per_second)
 
-        chain.execute(self.ct.repay(1, 13_000))
+        chain.execute(self.ct.repay(1, 13_000, chain.now + 2))
         
         # nothing left to repay
         with self.assertRaises(MichelsonRuntimeError):
-            chain.execute(self.ct.repay(1, 1))
+            chain.execute(self.ct.repay(1, 1, chain.now + 2))
 
         # bob borrows in the meantime
-        chain.execute(self.ct.mint(0, 40_000), sender=bob)
+        chain.execute(self.ct.mint(0, 40_000, 1), sender=bob)
         chain.execute(self.ct.enterMarket(0), sender=bob)
-        chain.execute(self.ct.borrow(1, 10_000), sender=bob)
+        chain.execute(self.ct.borrow(1, 10_000, chain.now + 2), sender=bob)
         
         chain.advance_blocks(1)
         self.update_price_and_interest(chain, 0, 100, one_percent_per_second)
         self.update_price_and_interest(chain, 1, 100, one_percent_per_second)
 
-        chain.execute(self.ct.repay(1, 13_000), sender=bob)
+        chain.execute(self.ct.repay(1, 13_000, chain.now + 2), sender=bob)
         
         # alice repeats everything as the first time
-        chain.execute(self.ct.borrow(1, 10_000))
+        chain.execute(self.ct.borrow(1, 10_000, chain.now + 2))
         
         chain.advance_blocks(1)
 
@@ -882,10 +882,10 @@ class DexTest(TestCase):
         self.update_price_and_interest(chain, 1, 100, one_percent_per_second)
 
         # not meaningful, just to add some mess
-        chain.execute(self.ct.redeem(0, 10_000))
+        chain.execute(self.ct.redeem(0, 10_000, 1))
 
         # chain.execute(self.ct.repay(1, 10_030))
-        res = chain.execute(self.ct.repay(1, 0))
+        res = chain.execute(self.ct.repay(1, 0, chain.now + 2))
         txs = parse_transfers(res)
         self.assertEqual(len(txs), 1)
         self.assertEqual(txs[0]["amount"], 13_000)      
@@ -896,20 +896,20 @@ class DexTest(TestCase):
         self.add_token(chain, token_a)
         self.add_token(chain, token_b)
 
-        chain.execute(self.ct.mint(0, 40_000))
+        chain.execute(self.ct.mint(0, 40_000, 1))
         chain.execute(self.ct.enterMarket(0))
         
-        chain.execute(self.ct.borrow(1, 10_000))
+        chain.execute(self.ct.borrow(1, 10_000, chain.now + 2))
 
         chain.advance_blocks(1)
 
         self.update_price_and_interest(chain, 0, 100, one_percent_per_second)
         self.update_price_and_interest(chain, 1, 100, one_percent_per_second)
 
-        chain.execute(self.ct.repay(1, 13_000))
+        chain.execute(self.ct.repay(1, 13_000, chain.now + 2))
         # nothing left to repay
         with self.assertRaises(MichelsonRuntimeError):
-            chain.execute(self.ct.repay(1, 1))
+            chain.execute(self.ct.repay(1, 1, chain.now + 2))
         
         res = chain.execute(self.ct.withdrawReserve(1, 1_500), sender=admin)
         transfers = parse_transfers(res)
@@ -920,19 +920,19 @@ class DexTest(TestCase):
             chain.execute(self.ct.withdrawReserve(1, 1), sender=admin)
 
         # bob borrows [0] in the meantime
-        chain.execute(self.ct.mint(1, 40_000), sender=bob)
+        chain.execute(self.ct.mint(1, 40_000, 1), sender=bob)
         chain.execute(self.ct.enterMarket(1), sender=bob)
-        chain.execute(self.ct.borrow(0, 10_000), sender=bob)
+        chain.execute(self.ct.borrow(0, 10_000, chain.now + 2), sender=bob)
 
         chain.advance_blocks(1)
 
         self.update_price_and_interest(chain, 0, 100, one_percent_per_second)
         self.update_price_and_interest(chain, 1, 100, one_percent_per_second)
 
-        chain.execute(self.ct.repay(0, 13_000), sender=bob)
+        chain.execute(self.ct.repay(0, 13_000, chain.now + 2), sender=bob)
         # nothing left to repay
         with self.assertRaises(MichelsonRuntimeError):
-            chain.execute(self.ct.repay(1, 1))
+            chain.execute(self.ct.repay(1, 1, chain.now + 2))
         # receive rewards after bob borrow
         res = chain.execute(self.ct.withdrawReserve(0, 1_500), sender=admin)
         transfers = parse_transfers(res)
@@ -941,7 +941,7 @@ class DexTest(TestCase):
             chain.execute(self.ct.withdrawReserve(0, 1), sender=admin)
 
         # `me` repeats everything as the first time
-        chain.execute(self.ct.borrow(1, 10_000))
+        chain.execute(self.ct.borrow(1, 10_000, chain.now + 2))
 
         chain.advance_blocks(1)
 
@@ -949,14 +949,14 @@ class DexTest(TestCase):
         self.update_price_and_interest(chain, 1, 100, one_percent_per_second)
 
         # not meaningful, just to add some mess
-        chain.execute(self.ct.redeem(0, 10_000))
-        res = chain.execute(self.ct.repay(1, 0))
+        chain.execute(self.ct.redeem(0, 10_000, 1))
+        res = chain.execute(self.ct.repay(1, 0, chain.now + 2))
         txs = parse_transfers(res)
         self.assertEqual(len(txs), 1)
         self.assertEqual(txs[0]["amount"], 13_000)
         # nothing left to repay
         with self.assertRaises(MichelsonRuntimeError):
-            chain.execute(self.ct.repay(1, 1))
+            chain.execute(self.ct.repay(1, 1, chain.now + 2))
         # receive rewards after alice borrow
         res = chain.execute(self.ct.withdrawReserve(1, 1_500), sender=admin)
         transfers = parse_transfers(res)
@@ -991,9 +991,9 @@ class DexTest(TestCase):
         self.add_token(chain, token_a, config_a)
         self.add_token(chain, token_b, config_b)
 
-        chain.execute(self.ct.mint(0, 200_000))
+        chain.execute(self.ct.mint(0, 200_000, 1))
         chain.execute(self.ct.enterMarket(0))
-        chain.execute(self.ct.borrow(1, 12))
+        chain.execute(self.ct.borrow(1, 12, chain.now + 2))
 
         chain.advance_blocks((2 * 60 * 60) // 30) # 2 hours
 
@@ -1009,7 +1009,7 @@ class DexTest(TestCase):
 
         expected_reserves_bonus = calculate_reserves_bonus_by_liqidation(res.storage['storage']['tokens'], 1, 0, 1)
 
-        res = chain.execute(self.ct.liquidate(1, 0, me, 1), sender=bob)
+        res = chain.execute(self.ct.liquidate(1, 0, me, 1, 1, chain.now + 2), sender=bob)
 
         actual_reserves = get_reserves(res, 0)
         actual_reserves_bonus = (actual_reserves - initial_reserves)
@@ -1021,12 +1021,12 @@ class DexTest(TestCase):
         self.add_token(chain, token_b)
         self.add_token(chain, token_c)
 
-        chain.execute(self.ct.mint(0, 15_000))
-        chain.execute(self.ct.mint(1, 5_000))
+        chain.execute(self.ct.mint(0, 15_000, 1))
+        chain.execute(self.ct.mint(1, 5_000, 1))
         chain.execute(self.ct.enterMarket(0))
         chain.execute(self.ct.enterMarket(1))
-        chain.execute(self.ct.borrow(2, 10_000))
-        chain.execute(self.ct.repay(2, 2_500))
+        chain.execute(self.ct.borrow(2, 10_000, chain.now + 2))
+        chain.execute(self.ct.repay(2, 2_500, chain.now + 2))
         
         # can't exit fi
         with self.assertRaises(MichelsonRuntimeError):
@@ -1039,24 +1039,24 @@ class DexTest(TestCase):
         self.add_token(chain, token_a)
         self.add_token(chain, token_b)
 
-        chain.execute(self.ct.mint(0, 15_000), sender=alice)
+        chain.execute(self.ct.mint(0, 15_000, 1), sender=alice)
 
-        chain.execute(self.ct.mint(1, 75_000), sender=bob)
+        chain.execute(self.ct.mint(1, 75_000, 1), sender=bob)
         chain.execute(self.ct.enterMarket(1), sender=bob)
-        chain.execute(self.ct.borrow(0, 10_000), sender=bob)
+        chain.execute(self.ct.borrow(0, 10_000, chain.now + 2), sender=bob)
 
         chain.advance_blocks(100)
         self.update_price_and_interest(chain, 0, 100, one_percent_per_second)
         self.update_price_and_interest(chain, 1, 100, one_percent_per_second)
         
         # repay everything
-        res = chain.execute(self.ct.repay(0, 0), sender=bob)
+        res = chain.execute(self.ct.repay(0, 0, chain.now + 2), sender=bob)
 
-        res = chain.execute(self.ct.mint(0, 10_000), sender=carol)
+        res = chain.execute(self.ct.mint(0, 10_000, 1), sender=carol)
         transfers = parse_transfers(res)
         self.assertEqual(transfers[0]["amount"], 10_000)
         
-        res = chain.execute(self.ct.redeem(0, 0), sender=carol)
+        res = chain.execute(self.ct.redeem(0, 0, 1), sender=carol)
         transfers = parse_transfers(res)
         self.assertAlmostEqual(transfers[0]["amount"], 10_000, delta=1)
 

--- a/integration_tests/test_transfers.py
+++ b/integration_tests/test_transfers.py
@@ -65,18 +65,18 @@ class DexTest(TestCase):
         liquidity = config["liquidity"]
         if liquidity == 0: return
 
-        chain.execute(self.ct.mint(token_num, liquidity), sender=admin)
+        chain.execute(self.ct.mint(token_num, liquidity, 1), sender=admin)
 
     def test_simple_transfer(self):
         chain = LocalChain(storage=self.storage)
         self.add_token(chain, token_a)
         self.add_token(chain, token_b)
 
-        chain.execute(self.ct.mint(0, 100_000), sender=alice)
+        chain.execute(self.ct.mint(0, 100_000, 1), sender=alice)
 
         chain.execute(self.ct.enterMarket(0), sender=bob)
         with self.assertRaises(MichelsonRuntimeError):
-            chain.execute(self.ct.borrow(0, 1), sender=bob)
+            chain.execute(self.ct.borrow(0, 1, chain.now + 2), sender=bob)
 
         transfer = self.ct.transfer(
             [{ "from_" : alice,
@@ -90,19 +90,19 @@ class DexTest(TestCase):
         res = chain.execute(transfer, sender=alice)
 
         with self.assertRaises(MichelsonRuntimeError):
-            chain.execute(self.ct.borrow(1, 5_001), sender=bob)
-        chain.execute(self.ct.borrow(1, 5_000), sender=bob)
+            chain.execute(self.ct.borrow(1, 5_001, chain.now + 2), sender=bob)
+        chain.execute(self.ct.borrow(1, 5_000, chain.now + 2), sender=bob)
 
     def test_zero_transfer(self):
         chain = LocalChain(storage=self.storage)
         self.add_token(chain, token_a)
         self.add_token(chain, token_b)
 
-        chain.execute(self.ct.mint(0, 10_000), sender=alice)
+        chain.execute(self.ct.mint(0, 10_000, 1), sender=alice)
 
         chain.execute(self.ct.enterMarket(0), sender=bob)
         with self.assertRaises(MichelsonRuntimeError):
-            chain.execute(self.ct.borrow(0, 1), sender=bob)
+            chain.execute(self.ct.borrow(0, 1, chain.now + 2), sender=bob)
 
         transfer = self.ct.transfer(
             [{ "from_" : alice,
@@ -123,12 +123,12 @@ class DexTest(TestCase):
         res = chain.execute(transfer, sender=alice)
 
         with self.assertRaises(MichelsonRuntimeError):
-            chain.execute(self.ct.redeem(0, 1), sender=bob)
+            chain.execute(self.ct.redeem(0, 1, chain.now + 2), sender=bob)
 
         # alice cannot borrow more than 5000. e.g. her balance is unchanged
         with self.assertRaises(MichelsonRuntimeError):
-            chain.execute(self.ct.redeem(0, 10_000 + 1), sender=alice)
-        chain.execute(self.ct.redeem(0, 10_000), sender=alice)
+            chain.execute(self.ct.redeem(0, 10_000 + 1, chain.now + 2), sender=alice)
+        chain.execute(self.ct.redeem(0, 10_000, chain.now + 2), sender=alice)
 
 
 

--- a/test/utils/yToken.js
+++ b/test/utils/yToken.js
@@ -5,6 +5,7 @@ const storage = require("../../storage/yToken");
 const { functions } = require("../../storage/functions");
 const { getLigo } = require("../../scripts/helpers");
 const { execSync } = require("child_process");
+const BigNumber = require("bignumber.js");
 
 class YToken {
   contract;
@@ -287,53 +288,80 @@ class YToken {
     closeFactorF,
     liqIncentiveF,
     priceFeedProxy,
-    maxMarkets,
+    maxMarkets
   ) {
     const operation = await this.contract.methods
-      .setGlobalFactors(
-        closeFactorF,
-        liqIncentiveF,
-        priceFeedProxy,
-        maxMarkets,
-      )
+      .setGlobalFactors(closeFactorF, liqIncentiveF, priceFeedProxy, maxMarkets)
       .send();
     await confirmOperation(this.tezos, operation.hash);
     return operation;
   }
 
-  async mint(token_id, amount) {
-    const operation = await this.contract.methods.mint(token_id, amount).send();
+  async mint(token_id, amount, minReceive = 1) {
+    const operation = await this.contract.methods
+      .mint(token_id, amount, minReceive)
+      .send();
     await confirmOperation(this.tezos, operation.hash);
     return operation;
   }
 
-  async redeem(token_id, amount) {
+  async redeem(token_id, amount, minReceive = 1) {
     const operation = await this.contract.methods
-      .redeem(token_id, amount)
+      .redeem(token_id, amount, minReceive)
       .send();
     await confirmOperation(this.tezos, operation.hash);
     return operation;
   }
 
   async borrow(token_id, amount) {
+    const deadline = Date.parse(
+      (await this.tezos.rpc.getBlockHeader()).timestamp
+    );
     const operation = await this.contract.methods
-      .borrow(token_id, amount)
+      .borrow(
+        token_id,
+        amount,
+        new BigNumber(deadline).dividedToIntegerBy(1000).plus(200)
+      )
       .send();
     await confirmOperation(this.tezos, operation.hash);
     return operation;
   }
 
   async repay(token_id, amount) {
+    const deadline = Date.parse(
+      (await this.tezos.rpc.getBlockHeader()).timestamp
+    );
     const operation = await this.contract.methods
-      .repay(token_id, amount)
+      .repay(
+        token_id,
+        amount,
+        new BigNumber(deadline).dividedToIntegerBy(1000).plus(200)
+      )
       .send();
     await confirmOperation(this.tezos, operation.hash);
     return operation;
   }
 
-  async liquidate(borrowToken, collateralToken, borrower, amount) {
+  async liquidate(
+    borrowToken,
+    collateralToken,
+    borrower,
+    amount,
+    minSeized = 1
+  ) {
+    const deadline = Date.parse(
+      (await this.tezos.rpc.getBlockHeader()).timestamp
+    );
     const operation = await this.contract.methods
-      .liquidate(borrowToken, collateralToken, borrower, amount)
+      .liquidate(
+        borrowToken,
+        collateralToken,
+        borrower,
+        amount,
+        minSeized,
+        new BigNumber(deadline).dividedToIntegerBy(1000).plus(200)
+      )
       .send();
     await confirmOperation(this.tezos, operation.hash);
     return operation;
@@ -472,7 +500,7 @@ class YToken {
     return operation;
   }
 
-  async updateAndMint(proxy, token, amount) {
+  async updateAndMint(proxy, token, amount, minReceive = 1) {
     const batchArray = [
       {
         kind: "transaction",
@@ -492,7 +520,9 @@ class YToken {
       },
       {
         kind: "transaction",
-        ...this.contract.methods.mint(token, amount).toTransferParams(),
+        ...this.contract.methods
+          .mint(token, amount, minReceive)
+          .toTransferParams(),
       },
     ];
     const batch = await this.tezos.wallet.batch(batchArray);
@@ -504,7 +534,7 @@ class YToken {
     return operation;
   }
 
-  async updateAndMint2(proxy, token, amount) {
+  async updateAndMint2(proxy, token, amount, minReceive = 1) {
     const batchArray = [
       {
         kind: "transaction",
@@ -524,7 +554,9 @@ class YToken {
       },
       {
         kind: "transaction",
-        ...this.contract.methods.mint(token, amount).toTransferParams(),
+        ...this.contract.methods
+          .mint(token, amount, minReceive)
+          .toTransferParams(),
       },
     ];
     const batch = await this.tezos.wallet.batch(batchArray);
@@ -535,6 +567,9 @@ class YToken {
   }
 
   async updateAndBorrow(proxy, borrowToken, amount) {
+    const deadline = Date.parse(
+      (await this.tezos.rpc.getBlockHeader()).timestamp
+    );
     const batchArray = [
       {
         kind: "transaction",
@@ -554,7 +589,13 @@ class YToken {
       },
       {
         kind: "transaction",
-        ...this.contract.methods.borrow(borrowToken, amount).toTransferParams(),
+        ...this.contract.methods
+          .borrow(
+            borrowToken,
+            amount,
+            new BigNumber(deadline).dividedToIntegerBy(1000).plus(200)
+          )
+          .toTransferParams(),
       },
     ];
     const batch = await this.tezos.wallet.batch(batchArray);
@@ -566,6 +607,9 @@ class YToken {
   }
 
   async updateAndBorrow2(proxy, borrowToken, amount) {
+    const deadline = Date.parse(
+      (await this.tezos.rpc.getBlockHeader()).timestamp
+    );
     const batchArray = [
       {
         kind: "transaction",
@@ -585,7 +629,13 @@ class YToken {
       },
       {
         kind: "transaction",
-        ...this.contract.methods.borrow(borrowToken, amount).toTransferParams(),
+        ...this.contract.methods
+          .borrow(
+            borrowToken,
+            amount,
+            new BigNumber(deadline).dividedToIntegerBy(1000).plus(200)
+          )
+          .toTransferParams(),
       },
     ];
     const batch = await this.tezos.wallet.batch(batchArray);
@@ -596,6 +646,9 @@ class YToken {
   }
 
   async updateAndRepay(proxy, repayToken, amount) {
+    const deadline = Date.parse(
+      (await this.tezos.rpc.getBlockHeader()).timestamp
+    );
     const batchArray = [
       {
         kind: "transaction",
@@ -607,7 +660,13 @@ class YToken {
       },
       {
         kind: "transaction",
-        ...this.contract.methods.repay(repayToken, amount).toTransferParams(),
+        ...this.contract.methods
+          .repay(
+            repayToken,
+            amount,
+            new BigNumber(deadline).dividedToIntegerBy(1000).plus(200)
+          )
+          .toTransferParams(),
       },
     ];
     const batch = await this.tezos.wallet.batch(batchArray);
@@ -618,7 +677,7 @@ class YToken {
     return operation;
   }
 
-  async updateAndRedeem(proxy, redeemToken, amount) {
+  async updateAndRedeem(proxy, redeemToken, amount, minReceive = 1) {
     const batch = await this.tezos.wallet.batch([
       {
         kind: "transaction",
@@ -638,7 +697,7 @@ class YToken {
       },
       {
         kind: "transaction",
-        ...this.contract.methods.redeem(redeemToken, amount).toTransferParams(),
+        ...this.contract.methods.redeem(redeemToken, amount, minReceive).toTransferParams(),
       },
     ]);
     const operation = await batch.send();
@@ -704,7 +763,10 @@ class YToken {
     return operation;
   }
 
-  async updateAndLiq(proxy, borrowToken, collateralToken, borrower, amount) {
+  async updateAndLiq(proxy, borrowToken, collateralToken, borrower, amount, minReceive = 1) {
+    const deadline = Date.parse(
+      (await this.tezos.rpc.getBlockHeader()).timestamp
+    );
     const batch = await this.tezos.wallet.batch([
       {
         kind: "transaction",
@@ -729,7 +791,14 @@ class YToken {
       {
         kind: "transaction",
         ...this.contract.methods
-          .liquidate(borrowToken, collateralToken, borrower, amount)
+          .liquidate(
+            borrowToken,
+            collateralToken,
+            borrower,
+            amount,
+            minReceive,
+            new BigNumber(deadline).dividedToIntegerBy(1000).plus(200)
+          )
           .toTransferParams(),
       },
     ]);


### PR DESCRIPTION
Add new params to yToken core methods:

Added parameter `minReceived`

 - `Mint`
 - `Redeem`

Added parameter `deadline`
 
 - `Borrow`
 - `Repay`
 
 To the method `Liquidate` added 2 params: `minSeized` and `deadline`.

Update tests for new params 
Added tests (pytezos) for new errors thrown by new params